### PR TITLE
Fix DISABLE_WEB_SERVER flag

### DIFF
--- a/src/SpotifyEsp32.cpp
+++ b/src/SpotifyEsp32.cpp
@@ -320,33 +320,35 @@ bool Spotify::token_base_req(String payload){
   _client.println(payload); 
   return true;
 }
-bool Spotify::get_refresh_token() {
-  Serial.println("Getting refresh token");
-  bool reply = false;
-  String payload = "grant_type=authorization_code&code=" + String(_auth_code) + "&redirect_uri=" + String(_redirect_uri)+ "callback";
-  if(!token_base_req(payload)){
-    _client.stop();
-    return false;
-  }
-  header_resp header_data = process_headers();
+#ifndef DISABLE_WEB_SERVER
+  bool Spotify::get_refresh_token() {
+    Serial.println("Getting refresh token");
+    bool reply = false;
+    String payload = "grant_type=authorization_code&code=" + String(_auth_code) + "&redirect_uri=" + String(_redirect_uri)+ "callback";
+    if(!token_base_req(payload)){
+      _client.stop();
+      return false;
+    }
+    header_resp header_data = process_headers();
 
-  JsonDocument filter;
-  filter["refresh_token"] = true;
-  JsonDocument response = process_response(header_data, filter);
-  if(!response.isNull()){
-    Serial.println("Got refresh token");
-    reply = true;
-    strncpy(_refresh_token, response["refresh_token"].as<const char*>(), sizeof(_refresh_token));
+    JsonDocument filter;
+    filter["refresh_token"] = true;
+    JsonDocument response = process_response(header_data, filter);
+    if(!response.isNull()){
+      Serial.println("Got refresh token");
+      reply = true;
+      strncpy(_refresh_token, response["refresh_token"].as<const char*>(), sizeof(_refresh_token));
+    }
+    if (_debug_on) {
+      Serial.printf("POST \"refresh token\" Status: %d \n", header_data.http_code);
+      Serial.print("Reply: ");
+      serializeJson(response, Serial);
+      Serial.println();
+    }
+    _client.stop();
+    return reply;
   }
-  if (_debug_on) {
-    Serial.printf("POST \"refresh token\" Status: %d \n", header_data.http_code);
-    Serial.print("Reply: ");
-    serializeJson(response, Serial);
-    Serial.println();
-  }
-  _client.stop();
-  return reply;
-}
+#endif
 bool Spotify::get_token() {
   bool reply = false;
   String payload = "grant_type=refresh_token&refresh_token=" + String(_refresh_token);

--- a/src/SpotifyEsp32.h
+++ b/src/SpotifyEsp32.h
@@ -41,10 +41,10 @@ namespace Spotify_types {
   extern const char* TYPE_ALBUM;
   extern const char* TYPE_ARTIST;
   extern const char* TYPE_TRACK;
+  extern const char* TYPE_PLAYLIST;
   extern const char* TYPE_SHOW;
   extern const char* TYPE_EPISODE;
   extern const char* TYPE_AUDIOBOOK;
-  extern const char* TYPE_PLAYLIST;
   extern const char* TOP_TYPE_ARTIST;
   extern const char* TOP_TYPE_TRACKS;
   extern const char* GROUP_ALBUM;


### PR DESCRIPTION
- Put the Spotify_types in the same order in `SpotifyEsp32.h` as in `SpotifyEsp32.cpp`. 
- Added `#ifndef DISABLE_WEB_SERVER` around `get_refresh_token` in `SpotifyEsp32.cpp`, as this is also done in `SpotifyEsp32.h` and caused errors when actually using `DISABLE_WEB_SERVER`.