### PR TITLE
Added get_current_album_image_url function

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ To print the response you can use the ```print_response(response_obj)``` functio
     //Convert a context id to a uri and return it as a char
     char convert_id_to_uri(char* id, char* type);
     //Convert a context id to a uri and return it as a pointer to the char
-    char* convert_id_to_uri(char* id, char* type, char* uri); 
+    char* convert_id_to_uri(char* id, char* type, char* uri);
+    //get current album url
+    string get_current_album_image_url(int image_int);
 ```
 - You can also include the namespace: ```using namespace Spotify_types;```. These are some types used in the library eg. TYPES, SIZES of uris/ids </br>
 ### Other Functions

--- a/src/SpotifyEsp32.cpp
+++ b/src/SpotifyEsp32.cpp
@@ -1529,6 +1529,16 @@ response Spotify::check_if_users_follow_playlist(const char* playlist_id, int si
 #endif
 //Simplified functions, formatting functions
 #ifndef DISABLE_SIMPLIFIED
+String Spotify::get_current_album_image_url(int image_int){
+    String album_url = "Something went wrong";
+    JsonDocument filter;
+    filter["item"]["album"]["images"][image_int]["url"] = true;
+    response data = currently_playing(filter);
+    if(valid_http_code(data.status_code) && !data.reply.isNull()){
+      album_url = data.reply["item"]["album"]["images"][image_int]["url"].as<String>();
+    }
+    return album_url;
+}
 String Spotify::current_track_name(){
   String track_name = "Something went wrong";
   JsonDocument filter;

--- a/src/SpotifyEsp32.h
+++ b/src/SpotifyEsp32.h
@@ -230,6 +230,10 @@ class Spotify {
     response add_to_queue(const char* context_uri);
     #endif
   #ifndef DISABLE_ALBUM
+    /// @brief Get current album cover link
+    /// @param int image array position
+    /// @return Current album cover link as String
+    String get_current_album_image_url(int image_int);
     /// @brief Get Spotify information for a single album.
     /// @param album_id Spotify ID of the album
     /// @param filter JsonDocument containing the fields to filter(Optional, returns all fields if not provided)

--- a/src/SpotifyEsp32.h
+++ b/src/SpotifyEsp32.h
@@ -230,10 +230,6 @@ class Spotify {
     response add_to_queue(const char* context_uri);
     #endif
   #ifndef DISABLE_ALBUM
-    /// @brief Get current album cover link
-    /// @param int image array position
-    /// @return Current album cover link as String
-    String get_current_album_image_url(int image_int);
     /// @brief Get Spotify information for a single album.
     /// @param album_id Spotify ID of the album
     /// @param filter JsonDocument containing the fields to filter(Optional, returns all fields if not provided)
@@ -738,6 +734,10 @@ class Spotify {
     /// @brief Get if it is possible to modify volume on current device
     /// @return true if it is possible to modify volume on current device
     bool volume_modifyable();
+  /// @brief Get current album cover link
+    /// @param int image array position
+    /// @return Current album cover link as String
+    String get_current_album_image_url(int image_int);
     #endif
     /// @brief Convert ID to URI
     /// @param id ID to convert


### PR DESCRIPTION
This function gives out an url in a string format to the current's song album cover, it takes an int as a value which reppresents the image array position in the spotify json file.
Code snippet with basic usage:
`
String AlbumImageURL = sp.get_current_album_image_url(0);
Serial.println(AlbumImageURL);
`

Output:
`https://i.scdn.co/image/ab67616d0000b27332f5fec7a879ed6ef28f0dfd`