### PR TITLE
Fix OAuth authorize URL encoding that breaks initial setup

### DIFF
--- a/src/SpotifyEsp32.cpp
+++ b/src/SpotifyEsp32.cpp
@@ -91,8 +91,13 @@ void Spotify::begin(){
       SPOTIFY_LOGD(_TAG, "Using default scopes: all");
     }
 
+    char encoded_redirect_uri[256];
+    char encoded_scopes[768];
+    urlEncode(_redirect_uri, encoded_redirect_uri, sizeof(encoded_redirect_uri));
+    urlEncode(scopes, encoded_scopes, sizeof(encoded_scopes));
+
     char url[1024];
-    snprintf(url, sizeof(url),"https://accounts.spotify.com/authorize" "?client_id=%s" "&response_type=code" "&redirect_uri=%s" "&scope=%s" "&state=%s", _client_id, _redirect_uri, scopes,_random_state);
+    snprintf(url, sizeof(url),"https://accounts.spotify.com/authorize" "?client_id=%s" "&response_type=code" "&redirect_uri=%s" "&scope=%s" "&state=%s", _client_id, encoded_redirect_uri, encoded_scopes, _random_state);
 
     Serial.println("Open this URL in your browser to authorize:");
     Serial.println(url);


### PR DESCRIPTION
## Description

This PR fixes an issue in the OAuth login flow that caused the initial setup to fail when using the library without a saved refresh token.

According to the documented setup flow, the library should:
- print an authorization URL to Serial
- let the user authenticate with Spotify
- receive the authorization callback
- exchange the returned code for a refresh token
- print that refresh token so it can be reused later

In my case, that first-time setup never completed. After logging in, I was redirected to the hosted callback URL, but the page responded with:

`Missing code or state`

Because of that, authentication never finished, `setup()` stayed blocked waiting for `is_auth()`, and the refresh token was never printed.

## Cause

The authorization URL was being built with raw `redirect_uri` and `scope` values. Since `scope` contains spaces and was not URL-encoded, the resulting URL could be malformed or parsed incorrectly, which appears to break preservation of the `state` parameter during the OAuth redirect.

## Changes

- URL-encode `redirect_uri` before inserting it into the authorization URL
- URL-encode `scope` before inserting it into the authorization URL

## Result

With this change, the generated Spotify authorization URL is properly encoded, and the initial authentication flow can complete as expected, allowing the refresh token to be obtained during first-time setup.
